### PR TITLE
Fix: Replace hardcoded ObjectPool.dll reference with NuGet package

### DIFF
--- a/src/DispatchR/DispatchR.csproj
+++ b/src/DispatchR/DispatchR.csproj
@@ -8,13 +8,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
+      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.4" />
       <PackageReference Include="ZLinq" Version="1.4.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="Microsoft.Extensions.ObjectPool">
-        <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\shared\Microsoft.AspNetCore.App\9.0.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
-      </Reference>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR removes the manual reference to `Microsoft.Extensions.ObjectPool.dll` using an absolute path, which caused build issues on machines without the same SDK layout.
