### PR TITLE
Remove 'new()' constraint from generic type parameters

### DIFF
--- a/src/DispatchR/Requests/IMediator.cs
+++ b/src/DispatchR/Requests/IMediator.cs
@@ -9,10 +9,10 @@ namespace DispatchR.Requests;
 public interface IMediator
 {
     TResponse Send<TRequest, TResponse>(IRequest<TRequest, TResponse> request,
-        CancellationToken cancellationToken) where TRequest : class, IRequest, new();
+        CancellationToken cancellationToken) where TRequest : class, IRequest;
 
     IAsyncEnumerable<TResponse> CreateStream<TRequest, TResponse>(IStreamRequest<TRequest, TResponse> request,
-        CancellationToken cancellationToken) where TRequest : class, IStreamRequest, new();
+        CancellationToken cancellationToken) where TRequest : class, IStreamRequest;
 
     ValueTask Publish<TNotification>(TNotification request, CancellationToken cancellationToken)
         where TNotification : INotification;
@@ -21,14 +21,14 @@ public interface IMediator
 public sealed class Mediator(IServiceProvider serviceProvider) : IMediator
 {
     public TResponse Send<TRequest, TResponse>(IRequest<TRequest, TResponse> request,
-        CancellationToken cancellationToken) where TRequest : class, IRequest, new()
+        CancellationToken cancellationToken) where TRequest : class, IRequest
     {
         return serviceProvider.GetRequiredService<IRequestHandler<TRequest, TResponse>>()
             .Handle(Unsafe.As<TRequest>(request), cancellationToken);
     }
 
     public IAsyncEnumerable<TResponse> CreateStream<TRequest, TResponse>(IStreamRequest<TRequest, TResponse> request, 
-        CancellationToken cancellationToken) where TRequest : class, IStreamRequest, new()
+        CancellationToken cancellationToken) where TRequest : class, IStreamRequest
     {
         return serviceProvider.GetRequiredService<IStreamRequestHandler<TRequest, TResponse>>()
             .Handle(Unsafe.As<TRequest>(request), cancellationToken);

--- a/src/DispatchR/Requests/Send/IPipelineBehavior.cs
+++ b/src/DispatchR/Requests/Send/IPipelineBehavior.cs
@@ -3,7 +3,7 @@
 namespace DispatchR.Requests.Send;
 
 public interface IPipelineBehavior<TRequest, TResponse> : IRequestHandler<TRequest, TResponse> 
-    where TRequest : class, IRequest<TRequest, TResponse>, new()
+    where TRequest : class, IRequest<TRequest, TResponse>
 {
     public IRequestHandler<TRequest, TResponse> NextPipeline { get; set; }
 

--- a/src/DispatchR/Requests/Send/IRequest.cs
+++ b/src/DispatchR/Requests/Send/IRequest.cs
@@ -2,4 +2,4 @@
 
 public interface IRequest;
 
-public interface IRequest<TRequest, TResponse> : IRequest where TRequest : class, new();
+public interface IRequest<TRequest, TResponse> : IRequest where TRequest : class;

--- a/src/DispatchR/Requests/Send/IRequestHandler.cs
+++ b/src/DispatchR/Requests/Send/IRequestHandler.cs
@@ -6,7 +6,7 @@ public interface IRequestHandler
     {
     }
 }
-public interface IRequestHandler<TRequest, TResponse> : IRequestHandler where TRequest : class, IRequest, new()
+public interface IRequestHandler<TRequest, TResponse> : IRequestHandler where TRequest : class, IRequest
 {
     TResponse Handle(TRequest request, CancellationToken cancellationToken);
 }

--- a/src/DispatchR/Requests/Stream/IStreamPipelineBehavior.cs
+++ b/src/DispatchR/Requests/Stream/IStreamPipelineBehavior.cs
@@ -4,7 +4,7 @@ using DispatchR.Requests.Send;
 namespace DispatchR.Requests.Stream;
 
 public interface IStreamPipelineBehavior<TRequest, TResponse> : IStreamRequestHandler<TRequest, TResponse> 
-    where TRequest : class, IStreamRequest<TRequest, TResponse>, new()
+    where TRequest : class, IStreamRequest<TRequest, TResponse>
 {
     public IStreamRequestHandler<TRequest, TResponse> NextPipeline { get; set; }
 

--- a/src/DispatchR/Requests/Stream/IStreamRequest.cs
+++ b/src/DispatchR/Requests/Stream/IStreamRequest.cs
@@ -2,4 +2,4 @@
 
 public interface IStreamRequest;
 
-public interface IStreamRequest<TRequest, TResponse> : IStreamRequest where TRequest : class, new();
+public interface IStreamRequest<TRequest, TResponse> : IStreamRequest where TRequest : class;

--- a/src/DispatchR/Requests/Stream/IStreamRequestHandler.cs
+++ b/src/DispatchR/Requests/Stream/IStreamRequestHandler.cs
@@ -2,7 +2,7 @@ using DispatchR.Requests.Send;
 
 namespace DispatchR.Requests.Stream;
 
-public interface IStreamRequestHandler<TRequest, TResponse> : IRequestHandler where TRequest : class, IStreamRequest, new()
+public interface IStreamRequestHandler<TRequest, TResponse> : IRequestHandler where TRequest : class, IStreamRequest
 {
     IAsyncEnumerable<TResponse> Handle(TRequest request, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
I currently don't see any reason to use the 'new()' constraint on generic type parameters. Currently this would restrict my structs / records / classes that implement the `IRequest` interface to have an parameterless constructor.

----

This commit removes the `new()` constraint from generic type parameters in several interfaces and classes, allowing for a broader range of types to be used. Key changes include:

- In `IMediator.cs`, the `Send` and `CreateStream` methods no longer require `TRequest` to have a parameterless constructor.
- Updated `IPipelineBehavior.cs` to allow more flexible request types by removing the `new()` constraint.
- Similar updates made in `IRequest.cs`, `IRequestHandler.cs`, `IStreamPipelineBehavior.cs`, `IStreamRequest.cs`, and `IStreamRequestHandler.cs`.

These changes enhance the flexibility of the request and handler interfaces, enabling a wider variety of implementations. 