### PR TITLE
Update launch settings and add new HTTP requests

### DIFF
--- a/src/Sample/Properties/launchSettings.json
+++ b/src/Sample/Properties/launchSettings.json
@@ -13,8 +13,9 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:7160;http://localhost:5070",
+      "launchBrowser": true,
+      "launchUrl": "scalar",
+      "applicationUrl": "https://localhost:7160/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Sample/Sample.http
+++ b/src/Sample/Sample.http
@@ -1,6 +1,43 @@
 @Sample_HostAddress = http://localhost:5070
 
+# Weather Forecast
 GET {{Sample_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###
+
+# Send in MediatR with Pipeline
+GET {{Sample_HostAddress}}/Send/MediatR
+Accept: application/json
+
+###
+
+# Send in DispatchR with Pipeline
+GET {{Sample_HostAddress}}/Send/DispatchR
+Accept: application/json
+
+###
+
+# Stream in MediatR
+GET {{Sample_HostAddress}}/Stream/MediatR
+Accept: application/json
+
+###
+
+# Stream in DispatchR
+GET {{Sample_HostAddress}}/Stream/DispatchR
+Accept: application/json
+
+###
+
+# Notification in MediatR
+GET {{Sample_HostAddress}}/Notification/MediatR
+Accept: application/json
+
+###
+
+# Notification in DispatchR
+GET {{Sample_HostAddress}}/Notification/DispatchR
 Accept: application/json
 
 ###


### PR DESCRIPTION
Modified `launchSettings.json` to enable browser launch, set the launch URL to "scalar", and adjust the application URL.

Updated `Sample.http` with new GET requests for weather forecasts, MediatR, and DispatchR, including appropriate headers and comments for clarity.