### PR TITLE
feature: extended ConfigurationOptions to pass specific PipelineOrder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,24 @@ It's simple! Just use the following code:
 ```csharp
 builder.Services.AddDispatchR(typeof(MyCommand).Assembly, withPipelines: true, withNotifications: true);
 ```
-This code will automatically register all pipelines by default. If you need to register them in a specific order, you can either add them manually or write your own reflection logic:
+This code will automatically register all pipelines by default.
+If you need to register them in a specific order, you could pass the Order via ConfigurationOptions like in the sample below:
+```csharp
+builder.Services.AddDispatchR(options =>
+{
+    options.Assemblies.Add(typeof(DispatchRSample.Ping).Assembly);
+    options.RegisterPipelines = true;
+    options.RegisterNotifications = true;
+    options.PipelineOrder =
+    [
+        typeof(DispatchRSample.FirstPipelineBehavior),
+        typeof(DispatchRSample.SecondPipelineBehavior),
+        typeof(DispatchRSample.GenericPipelineBehavior<,>)
+    ];
+});
+```
+
+If you need additional customization, you can either add them manually or write your own reflection logic:
 ```csharp
 builder.Services.AddDispatchR(typeof(MyCommand).Assembly, withPipelines: false, withNotifications: false);
 builder.Services.AddScoped<IPipelineBehavior<MyCommand, int>, PipelineBehavior>();

--- a/src/DispatchR/Configuration/ConfigurationOptions.cs
+++ b/src/DispatchR/Configuration/ConfigurationOptions.cs
@@ -7,5 +7,6 @@ namespace DispatchR.Configuration
         public bool RegisterPipelines { get; set; } = true;
         public bool RegisterNotifications { get; set; } = true;
         public List<Assembly> Assemblies { get; } = new();
+        public List<Type>? PipelineOrder { get; set; }
     }
 }

--- a/src/DispatchR/Configuration/ServiceRegistrator.cs
+++ b/src/DispatchR/Configuration/ServiceRegistrator.cs
@@ -9,7 +9,7 @@ namespace DispatchR.Configuration
     {
         public static void RegisterHandlers(IServiceCollection services, List<Type> allTypes,
             Type requestHandlerType, Type pipelineBehaviorType, Type streamRequestHandlerType,
-            Type streamPipelineBehaviorType, bool withPipelines)
+            Type streamPipelineBehaviorType, bool withPipelines, List<Type>? pipelineOrder = null)
         {
             var allHandlers = allTypes
                 .Where(p =>
@@ -60,6 +60,19 @@ namespace DispatchR.Configuration
                                        ?.GetInterfaces().First().GetGenericTypeDefinition() ==
                                    handlerInterface.GetGenericTypeDefinition();
                         }).ToList();
+
+                    // Sort pipelines by the specified order passed via ConfigurationOptions
+                    if (pipelineOrder is { Count: > 0 })
+                    {
+                        pipelines = pipelines
+                            .OrderBy(p =>
+                            {
+                                var idx = pipelineOrder.IndexOf(p);
+                                return idx == -1 ? int.MaxValue : idx;
+                            })
+                            .ToList();
+                        pipelines.Reverse();
+                    }
 
                     foreach (var pipeline in pipelines)
                     {

--- a/src/DispatchR/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DispatchR/Extensions/ServiceCollectionExtensions.cs
@@ -64,7 +64,7 @@ public static class ServiceCollectionExtensions
         }
 
         ServiceRegistrator.RegisterHandlers(services, allTypes, requestHandlerType, pipelineBehaviorType,
-            streamRequestHandlerType, streamPipelineBehaviorType, configurationOptions.RegisterPipelines);
+            streamRequestHandlerType, streamPipelineBehaviorType, configurationOptions.RegisterPipelines, configurationOptions.PipelineOrder);
 
         return services;
     }

--- a/src/Sample/Program.cs
+++ b/src/Sample/Program.cs
@@ -23,7 +23,19 @@ builder.Services.AddTransient<MediatR.IPipelineBehavior<MediatRSample.Ping, int>
 builder.Services.AddTransient<MediatR.IPipelineBehavior<MediatRSample.Ping, int>, MediatRSample.SecondPipelineBehavior>();
 builder.Services.AddTransient<MediatR.IStreamPipelineBehavior<MediatRStreamSample.CounterStreamRequest, string>, MediatRStreamSample.CounterPipelineStreamHandler>();
 
-builder.Services.AddDispatchR(typeof(DispatchRSample.Ping).Assembly);
+builder.Services.AddDispatchR(options =>
+{
+    options.Assemblies.Add(typeof(DispatchRSample.Ping).Assembly);
+    options.RegisterPipelines = true;
+    options.RegisterNotifications = true;
+    options.PipelineOrder =
+    [
+        typeof(DispatchRSample.FirstPipelineBehavior),
+        typeof(DispatchRSample.SecondPipelineBehavior),
+        typeof(DispatchRSample.GenericPipelineBehavior<,>)
+    ];
+});
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
Sometimes, a specific order for pipelines is necessary. By extending the ConfigurationOptions with an Additional PipelineOrder-Property, we could define the order, in which the pipelines should be registered. By extending the ConfigurationOptions, we could 

```csharp
builder.Services.AddDispatchR(options =>
{
    options.Assemblies.Add(typeof(DispatchRSample.Ping).Assembly);
    options.RegisterPipelines = true;
    options.RegisterNotifications = true;
    options.PipelineOrder =
    [
        typeof(DispatchRSample.FirstPipelineBehavior),
        typeof(DispatchRSample.SecondPipelineBehavior),
        typeof(DispatchRSample.GenericPipelineBehavior<,>)
    ];
});
```

By expanding the options, we can keep the rest and don't have to worry about registering the individual pipelines ourselves.