### PR TITLE
✨ Add .NET 8 Support 

### DIFF
--- a/src/DispatchR/DispatchR.csproj
+++ b/src/DispatchR/DispatchR.csproj
@@ -1,28 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageId>DispatchR.Mediator</PackageId>
-        <Authors>hasanxdev</Authors>
-        <Description>
-            Fast, zero-alloc alternative to MediatR for .NET – minimal, blazing fast, and DI-friendly.
-        </Description>
-        <PackageTags>DispatchR;Mediator;MediatR</PackageTags>
-        <PackageProjectUrl>https://github.com/hasanxdev/DispatchR</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/hasanxdev/DispatchR</RepositoryUrl>
-    </PropertyGroup>
+	<PropertyGroup>
+		<!-- Multi-targeting for .NET 8 and 9 -->
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 
-    <ItemGroup>
-		<!--<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, )" />-->
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" Condition="'$(TargetFramework)' == 'net9.0'" />
+		<!-- Basic project settings -->
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<!-- NuGet package metadata -->
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageId>DispatchR.Mediator</PackageId>
+		<Authors>hasanxdev</Authors>
+		<Description>
+			Fast, zero-alloc alternative to MediatR for .NET – minimal, blazing fast, and DI-friendly.
+		</Description>
+		<PackageTags>DispatchR;Mediator;MediatR</PackageTags>
+		<PackageProjectUrl>https://github.com/hasanxdev/DispatchR</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/hasanxdev/DispatchR</RepositoryUrl>
+	</PropertyGroup>
+
+	<!-- Conditional NuGet packages for each framework -->
+	<ItemGroup>
+		<!-- Example of commented package reference -->
+
+		<!-- Version-specific references -->
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+                          Version="8.0.2"
+                          Condition="'$(TargetFramework)' == 'net8.0'" />
+
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+                          Version="9.0.6"
+                          Condition="'$(TargetFramework)' == 'net9.0'" />
 	</ItemGroup>
 
-    <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    </ItemGroup>
+	<!-- Include README in package -->
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 
 </Project>

--- a/src/DispatchR/DispatchR.csproj
+++ b/src/DispatchR/DispatchR.csproj
@@ -1,14 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
 	<PropertyGroup>
-		<!-- Multi-targeting for .NET 8 and 9 -->
 		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-
-		<!-- Basic project settings -->
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-
-		<!-- NuGet package metadata -->
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageId>DispatchR.Mediator</PackageId>
 		<Authors>hasanxdev</Authors>
@@ -19,24 +13,15 @@
 		<PackageProjectUrl>https://github.com/hasanxdev/DispatchR</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/hasanxdev/DispatchR</RepositoryUrl>
 	</PropertyGroup>
-
-	<!-- Conditional NuGet packages for each framework -->
 	<ItemGroup>
-		<!-- Example of commented package reference -->
-
-		<!-- Version-specific references -->
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
                           Version="8.0.2"
                           Condition="'$(TargetFramework)' == 'net8.0'" />
-
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
                           Version="9.0.6"
                           Condition="'$(TargetFramework)' == 'net9.0'" />
 	</ItemGroup>
-
-	<!-- Include README in package -->
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
-
 </Project>

--- a/src/DispatchR/DispatchR.csproj
+++ b/src/DispatchR/DispatchR.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -16,8 +16,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-    </ItemGroup>
+		<!--<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, )" />-->
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" Condition="'$(TargetFramework)' == 'net9.0'" />
+	</ItemGroup>
 
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath="\" />

--- a/src/Sample/Program.cs
+++ b/src/Sample/Program.cs
@@ -1,9 +1,5 @@
 using DispatchR.Extensions;
-using Microsoft.OpenApi.Models;
 using Scalar.AspNetCore;
-
-
-//using Scalar.AspNetCore;
 using DispatchRNotificationSample = Sample.DispatchR.Notification;
 using DispatchRSample = Sample.DispatchR.SendRequest;
 using DispatchRStreamSample = Sample.DispatchR.StreamRequest;
@@ -14,9 +10,7 @@ using MediatRStreamSample = Sample.MediatR.StreamRequest;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-
-//builder.Services.AddEndpointsApiExplorer();
-//builder.Services.AddSwaggerGen();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 
 builder.Services.AddMediatR(cfg =>
@@ -48,8 +42,6 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
-    //app.UseSwagger();
-    //app.UseSwaggerUI();
     app.MapOpenApi();
     app.MapScalarApiReference();
 }
@@ -62,17 +54,17 @@ var summaries = new[]
 };
 
 app.MapGet("/weatherforecast", () =>
-    {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
-    })
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+            new WeatherForecast
+            (
+                DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                Random.Shared.Next(-20, 55),
+                summaries[Random.Shared.Next(summaries.Length)]
+            ))
+        .ToArray();
+    return forecast;
+})
     .WithName("GetWeatherForecast");
 
 app.MapGet("/Send/MediatR", (MediatR.IMediator mediatR, CancellationToken cancellationToken)

--- a/src/Sample/Program.cs
+++ b/src/Sample/Program.cs
@@ -1,5 +1,7 @@
 using DispatchR.Extensions;
 using Microsoft.OpenApi.Models;
+using Scalar.AspNetCore;
+
 
 //using Scalar.AspNetCore;
 using DispatchRNotificationSample = Sample.DispatchR.Notification;
@@ -13,8 +15,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+//builder.Services.AddEndpointsApiExplorer();
+//builder.Services.AddSwaggerGen();
+builder.Services.AddOpenApi();
 
 builder.Services.AddMediatR(cfg =>
 {
@@ -45,8 +48,10 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    //app.UseSwagger();
+    //app.UseSwaggerUI();
+    app.MapOpenApi();
+    app.MapScalarApiReference();
 }
 
 app.UseHttpsRedirection();

--- a/src/Sample/Program.cs
+++ b/src/Sample/Program.cs
@@ -1,5 +1,7 @@
 using DispatchR.Extensions;
-using Scalar.AspNetCore;
+using Microsoft.OpenApi.Models;
+
+//using Scalar.AspNetCore;
 using DispatchRNotificationSample = Sample.DispatchR.Notification;
 using DispatchRSample = Sample.DispatchR.SendRequest;
 using DispatchRStreamSample = Sample.DispatchR.StreamRequest;
@@ -10,8 +12,9 @@ using MediatRStreamSample = Sample.MediatR.StreamRequest;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 builder.Services.AddMediatR(cfg =>
 {
@@ -42,8 +45,8 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
-    app.MapScalarApiReference();
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
 
 app.UseHttpsRedirection();

--- a/src/Sample/Properties/launchSettings.json
+++ b/src/Sample/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "scalar",
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7160/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/Sample/Properties/launchSettings.json
+++ b/src/Sample/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "applicationUrl": "https://localhost:7160/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -2,16 +2,16 @@
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
-        <Nullable>enable</Nullable>
+        <!--<TargetFramework>net8.0</TargetFramework> --><!--Uncomment if you want to test .NET 8.0. Be sure to comment out other .NET versions-->
+		<Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
-        <PackageReference Include="MediatR" Version="12.5.0" />
-        <PackageReference Include="Scalar.AspNetCore" Version="2.4.7" />
-    </ItemGroup>
-
+	<ItemGroup>
+		<PackageReference Include="MediatR" Version="12.5.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+	</ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\DispatchR\DispatchR.csproj" />
     </ItemGroup>

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="MediatR" Version="12.5.0" />
-	</ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\DispatchR\DispatchR.csproj" />
-    </ItemGroup>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
+		<PackageReference Include="MediatR" Version="12.5.0" />
 		<PackageReference Include="Scalar.AspNetCore" Version="2.4.7" />
 	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DispatchR\DispatchR.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -9,11 +9,14 @@
 	<ItemGroup>
 		<PackageReference Include="MediatR" Version="12.5.0" />
 	</ItemGroup>
-	<ItemGroup>
+	<!--<ItemGroup>
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-	</ItemGroup>
+	</ItemGroup>-->
     <ItemGroup>
       <ProjectReference Include="..\DispatchR\DispatchR.csproj" />
     </ItemGroup>
-
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
+		<PackageReference Include="Scalar.AspNetCore" Version="2.4.7" />
+	</ItemGroup>
 </Project>

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -2,16 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
-        <!--<TargetFramework>net8.0</TargetFramework> --><!--Uncomment if you want to test .NET 8.0. Be sure to comment out other .NET versions-->
 		<Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="MediatR" Version="12.5.0" />
 	</ItemGroup>
-	<!--<ItemGroup>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-	</ItemGroup>-->
     <ItemGroup>
       <ProjectReference Include="..\DispatchR\DispatchR.csproj" />
     </ItemGroup>


### PR DESCRIPTION


1. Added multi-target support for .NET 8 alongside existing .NET 9

2. Replaced Swagger with Scalar due to compatibility issues with Service.AddOpenApi in .NET 8

3. Updated conditional NuGet packages for both frameworks

**Key Changes:**
```
        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
```
```
	<!-- Version-specific references -->
	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
                      Version="8.0.2"
                      Condition="'$(TargetFramework)' == 'net8.0'" />

	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
                      Version="9.0.6"
                      Condition="'$(TargetFramework)' == 'net9.0'" />
```

```
	<ItemGroup>
		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
	</ItemGroup>
```
Swagger → Scalar migration

Version-specific package references

**Notes:**

Maintained all existing functionality

README and metadata preserved