### PR TITLE
Add PublishObject method to support non-generic notifications

### DIFF
--- a/src/DispatchR/Constants.cs
+++ b/src/DispatchR/Constants.cs
@@ -1,0 +1,7 @@
+namespace DispatchR;
+
+internal class Constants
+{
+    private const string DiagnosticPrefix = "DR";
+    internal const string DiagnosticPerformanceIssue = $"{DiagnosticPrefix}1000";
+}

--- a/tests/DispatchR.IntegrationTest/NotificationTests.cs
+++ b/tests/DispatchR.IntegrationTest/NotificationTests.cs
@@ -44,4 +44,41 @@ public class NotificationTests
         spyPipelineTwoMock.Verify(p => p.Handle(It.IsAny<MultiHandlersNotification>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
         spyPipelineThreeMock.Verify(p => p.Handle(It.IsAny<MultiHandlersNotification>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
     }
+    
+    [Fact]
+    public async Task PublishObject_CallsAllHandlers_WhenMultipleHandlersAreRegistered()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddDispatchR(cfg =>
+        {
+            cfg.Assemblies.Add(typeof(Fixture).Assembly);
+            cfg.RegisterPipelines = false;
+            cfg.RegisterNotifications = true;
+        });
+        
+        var spyPipelineOneMock = new Mock<INotificationHandler<MultiHandlersNotification>>();
+        var spyPipelineTwoMock = new Mock<INotificationHandler<MultiHandlersNotification>>();
+        var spyPipelineThreeMock = new Mock<INotificationHandler<MultiHandlersNotification>>();
+
+        spyPipelineOneMock.Setup(p => p.Handle(It.IsAny<MultiHandlersNotification>(), It.IsAny<CancellationToken>()));
+        spyPipelineTwoMock.Setup(p => p.Handle(It.IsAny<MultiHandlersNotification>(), It.IsAny<CancellationToken>()));
+        spyPipelineThreeMock.Setup(p => p.Handle(It.IsAny<MultiHandlersNotification>(), It.IsAny<CancellationToken>()));
+        
+        services.AddScoped<INotificationHandler<MultiHandlersNotification>>(sp => spyPipelineOneMock.Object);
+        services.AddScoped<INotificationHandler<MultiHandlersNotification>>(sp => spyPipelineTwoMock.Object);
+        services.AddScoped<INotificationHandler<MultiHandlersNotification>>(sp => spyPipelineThreeMock.Object);
+        
+        var serviceProvider = services.BuildServiceProvider();
+        var mediator = serviceProvider.GetRequiredService<IMediator>();
+        
+        // Act
+        object notificationObject = new MultiHandlersNotification(Guid.Empty);
+        await mediator.Publish(notificationObject, CancellationToken.None);
+        
+        // Assert
+        spyPipelineOneMock.Verify(p => p.Handle(It.IsAny<MultiHandlersNotification>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+        spyPipelineTwoMock.Verify(p => p.Handle(It.IsAny<MultiHandlersNotification>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+        spyPipelineThreeMock.Verify(p => p.Handle(It.IsAny<MultiHandlersNotification>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+    }
 }


### PR DESCRIPTION
### Summary
As requested in issue #33, this PR introduces a new overload for method `Publish` in DispatchR that allows publishing notifications without requiring a concrete generic type. Users can now pass an `object` directly, providing more flexibility for dynamic scenarios.

### Changes
- Added `Publish(object request, CancellationToken cancellationToken)` method.
- Ensures backward compatibility with existing generic `Publish<TNotification>` methods and includes corresponding tests.

### Benefits
- Simplifies use cases where the notification type is not known at compile time.
- Avoids forcing users to create concrete types for temporary or dynamic notifications.
- Keeps DispatchR flexible and user-friendly.
