### PR TITLE
Fix awaitable response type comparison in async pipelines

### DIFF
--- a/src/DispatchR/Configuration/ServiceRegistrator.cs
+++ b/src/DispatchR/Configuration/ServiceRegistrator.cs
@@ -125,6 +125,14 @@ namespace DispatchR.Configuration
                                         continue;
                                     }
 
+                                    // If both are non-generic (Task vs ValueTask), then compare directly
+                                    if (!responseTypeArg.GenericTypeArguments.Any() &&
+                                        !genericHandlerResponseType.GenericTypeArguments.Any() &&
+                                        responseTypeArg != genericHandlerResponseType)
+                                    {
+                                        continue; // Task != ValueTask, so skip
+                                    }
+
                                     // register async generic pipelines
                                     if (responseTypeArg.GenericTypeArguments.Any())
                                     {

--- a/tests/DispatchR.TestCommon/Fixtures/Interfaces/INonGenericInterface.cs
+++ b/tests/DispatchR.TestCommon/Fixtures/Interfaces/INonGenericInterface.cs
@@ -1,0 +1,3 @@
+﻿namespace DispatchR.TestCommon.Fixtures.Interfaces;
+
+public interface INonGenericInterface;

--- a/tests/DispatchR.TestCommon/Fixtures/SendRequest/AsyncEnumerable/AsyncEnumerableHandler.cs
+++ b/tests/DispatchR.TestCommon/Fixtures/SendRequest/AsyncEnumerable/AsyncEnumerableHandler.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.CompilerServices;
+using DispatchR.Abstractions.Send;
+
+namespace DispatchR.TestCommon.Fixtures.SendRequest.AsyncEnumerable;
+
+public class AsyncEnumerableHandler : IRequestHandler<AsyncEnumerableRequest, IAsyncEnumerable<int>>
+{
+    public async IAsyncEnumerable<int> Handle(AsyncEnumerableRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return await System.Threading.Tasks.Task.FromResult(1);
+        yield return await System.Threading.Tasks.Task.FromResult(2);
+        yield return await System.Threading.Tasks.Task.FromResult(3);
+    }
+}

--- a/tests/DispatchR.TestCommon/Fixtures/SendRequest/AsyncEnumerable/AsyncEnumerableRequest.cs
+++ b/tests/DispatchR.TestCommon/Fixtures/SendRequest/AsyncEnumerable/AsyncEnumerableRequest.cs
@@ -1,0 +1,5 @@
+﻿using DispatchR.Abstractions.Send;
+
+namespace DispatchR.TestCommon.Fixtures.SendRequest.AsyncEnumerable;
+
+public class AsyncEnumerableRequest : IRequest<AsyncEnumerableRequest, IAsyncEnumerable<int>>;

--- a/tests/DispatchR.TestCommon/Fixtures/SendRequest/AsyncEnumerablePipelineBehavior.cs
+++ b/tests/DispatchR.TestCommon/Fixtures/SendRequest/AsyncEnumerablePipelineBehavior.cs
@@ -1,0 +1,21 @@
+﻿using System.Runtime.CompilerServices;
+using DispatchR.Abstractions.Send;
+using DispatchR.TestCommon.Fixtures.Interfaces;
+
+namespace DispatchR.TestCommon.Fixtures.SendRequest;
+
+public class AsyncEnumerablePipelineBehavior<TRequest, TResponse>
+    : INonGenericInterface,
+    IPipelineBehavior<TRequest, IAsyncEnumerable<TResponse>>
+    where TRequest : class, IRequest<TRequest, IAsyncEnumerable<TResponse>>, new()
+{
+    public required IRequestHandler<TRequest, IAsyncEnumerable<TResponse>> NextPipeline { get; set; }
+
+    public async IAsyncEnumerable<TResponse> Handle(TRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (var item in NextPipeline.Handle(request, cancellationToken))
+        {
+            yield return item;
+        }
+    }
+}

--- a/tests/DispatchR.TestCommon/Fixtures/SendRequest/GenericPipelineBehaviorTaskWithoutResponse.cs
+++ b/tests/DispatchR.TestCommon/Fixtures/SendRequest/GenericPipelineBehaviorTaskWithoutResponse.cs
@@ -1,0 +1,15 @@
+using DispatchR.Abstractions.Send;
+
+namespace DispatchR.TestCommon.Fixtures.SendRequest;
+
+public class GenericPipelineBehaviorTaskWithoutResponse<TRequest, TResponse>()
+    : IPipelineBehavior<TRequest, System.Threading.Tasks.Task>
+    where TRequest : class, IRequest<TRequest, System.Threading.Tasks.Task>, new()
+{
+    public System.Threading.Tasks.Task Handle(TRequest request, CancellationToken cancellationToken)
+    {
+        return NextPipeline.Handle(request, cancellationToken);
+    }
+
+    public required IRequestHandler<TRequest, System.Threading.Tasks.Task> NextPipeline { get; set; }
+}


### PR DESCRIPTION
Hi @hasanxdev,

I noticed another minor issue where if a pipeline behavior handles `Task` response type, the registrator still tries to register it against a request handler with `ValueTask` response type and vice versa, causing an exception "parameter constraint violation"

I've also added an extra test for request handler with `IAsyncEnumerable` return type to achieve 100% code coverage.