### PR TITLE
refactor: Move IMediator interface to abstractions package

### DIFF
--- a/src/DispatchR.Abstractions/IMediator.cs
+++ b/src/DispatchR.Abstractions/IMediator.cs
@@ -1,0 +1,30 @@
+using DispatchR.Abstractions.Notification;
+using DispatchR.Abstractions.Send;
+using DispatchR.Abstractions.Stream;
+
+namespace DispatchR;
+
+public interface IMediator
+{
+    TResponse Send<TRequest, TResponse>(IRequest<TRequest, TResponse> request,
+        CancellationToken cancellationToken) where TRequest : class, IRequest;
+
+    IAsyncEnumerable<TResponse> CreateStream<TRequest, TResponse>(IStreamRequest<TRequest, TResponse> request,
+        CancellationToken cancellationToken) where TRequest : class, IStreamRequest;
+
+    ValueTask Publish<TNotification>(TNotification request, CancellationToken cancellationToken)
+        where TNotification : INotification;
+    
+    /// <summary>
+    /// This method is not recommended for performance-critical scenarios.  
+    /// Use it only if it is strictly necessary, as its performance is lower compared  
+    /// to similar methods in terms of both memory usage and CPU consumption.  
+    /// </summary>
+    /// <param name="request">
+    /// An object that implements INotification
+    /// </param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [Obsolete(message: "This method has performance issues. Use only if strictly necessary", error: false)]
+    ValueTask Publish(object request, CancellationToken cancellationToken);
+}

--- a/src/DispatchR/Mediator.cs
+++ b/src/DispatchR/Mediator.cs
@@ -7,33 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace DispatchR;
 
-public interface IMediator
-{
-    TResponse Send<TRequest, TResponse>(IRequest<TRequest, TResponse> request,
-        CancellationToken cancellationToken) where TRequest : class, IRequest;
-
-    IAsyncEnumerable<TResponse> CreateStream<TRequest, TResponse>(IStreamRequest<TRequest, TResponse> request,
-        CancellationToken cancellationToken) where TRequest : class, IStreamRequest;
-
-    ValueTask Publish<TNotification>(TNotification request, CancellationToken cancellationToken)
-        where TNotification : INotification;
-    
-    /// <summary>
-    /// This method is not recommended for performance-critical scenarios.  
-    /// Use it only if it is strictly necessary, as its performance is lower compared  
-    /// to similar methods in terms of both memory usage and CPU consumption.  
-    /// </summary>
-    /// <param name="request">
-    /// An object that implements INotification
-    /// </param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    [Obsolete(message: "This method has performance issues. Use only if strictly necessary", 
-        error: false, 
-        DiagnosticId = Constants.DiagnosticPerformanceIssue)]
-    ValueTask Publish(object request, CancellationToken cancellationToken);
-}
-
 public sealed class Mediator(IServiceProvider serviceProvider) : IMediator
 {
     public TResponse Send<TRequest, TResponse>(IRequest<TRequest, TResponse> request,
@@ -73,6 +46,19 @@ public sealed class Mediator(IServiceProvider serviceProvider) : IMediator
         }
     }
 
+    /// <summary>
+    /// This method is not recommended for performance-critical scenarios.  
+    /// Use it only if it is strictly necessary, as its performance is lower compared  
+    /// to similar methods in terms of both memory usage and CPU consumption.  
+    /// </summary>
+    /// <param name="request">
+    /// An object that implements INotification
+    /// </param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [Obsolete(message: "This method has performance issues. Use only if strictly necessary", 
+        error: false, 
+        DiagnosticId = Constants.DiagnosticPerformanceIssue)]
     public async ValueTask Publish(object request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/src/DispatchR/TypeForwarders.cs
+++ b/src/DispatchR/TypeForwarders.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly:TypeForwardedTo(typeof(DispatchR.IMediator))]


### PR DESCRIPTION
I moved `IMediator` into the abstractions package :)

The idea is pretty simple: `IMediator` is an abstract interface, and in many places I don’t actually need the whole DispatchR package with its implementation.

For example:
- DispatchR is registered only in the main WebApp module.
- The API module contains only API controllers and uses just the `IMediator` interface.
- Same for the Domain module, it contains request and event handlers, and they also rely only on `IMediator` for side effects.

In these cases pulling the full DispatchR package feels like overkill — having just the abstractions is enough and keeps dependencies cleaner.

> I also used `TypeForwardedToAttribute` to keep backward compatibility, so this shouldn’t break anything.

Overall this isn’t a super important change, but it should be a bit more convenient for the cases above 😄