### PR TITLE
Fix stream handler include/exclude filtering

### DIFF
--- a/src/DispatchR/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DispatchR/Extensions/ServiceCollectionExtensions.cs
@@ -53,20 +53,32 @@ public static class ServiceCollectionExtensions
         var otherHandlerTypes = new HashSet<Type>()
         {
             pipelineBehaviorType,
-            streamRequestHandlerType,
             streamPipelineBehaviorType,
             syncNotificationHandlerType
         };
 
         var allTypes = configurationOptions.Assemblies.SelectMany(x => x.GetTypes()).Distinct()
-            .Where(p =>
-                p.GetInterfaces() is { Length: >= 1 } interfaces &&
-                       interfaces
-                           .Where(i => i.IsGenericType)
-                           .Select(i => i.GetGenericTypeDefinition())
-                    .Any(i => i == requestHandlerType
-                        ? configurationOptions.IsHandlerIncluded(p)
-                        : otherHandlerTypes.Contains(i)))
+            .Where(type =>
+            {
+                var genericInterfaces = type.GetInterfaces()
+                    .Where(i => i.IsGenericType)
+                    .Select(i => i.GetGenericTypeDefinition())
+                    .ToList();
+
+                var isRequestHandler = genericInterfaces.Contains(requestHandlerType);
+                var isPipelineBehavior = genericInterfaces.Contains(pipelineBehaviorType);
+                var isStreamRequestHandler = genericInterfaces.Contains(streamRequestHandlerType);
+                var isStreamPipelineBehavior = genericInterfaces.Contains(streamPipelineBehaviorType);
+
+                var isConcreteRequestHandler = isRequestHandler && !isPipelineBehavior;
+                var isConcreteStreamRequestHandler = isStreamRequestHandler && !isStreamPipelineBehavior;
+                if (isConcreteRequestHandler || isConcreteStreamRequestHandler)
+                {
+                    return configurationOptions.IsHandlerIncluded(type);
+                }
+
+                return genericInterfaces.Intersect(otherHandlerTypes).Any();
+            })
             .ToList();
 
         if (configurationOptions.RegisterNotifications)

--- a/tests/DispatchR.UnitTest/AddDispatchRConfigurationTests.cs
+++ b/tests/DispatchR.UnitTest/AddDispatchRConfigurationTests.cs
@@ -77,6 +77,48 @@ public class AddDispatchRConfigurationTests
     }
     
     [Fact]
+    public void AddDispatchR_DoesNotRegisterStreamHandler_WhenOnlyRequestHandlerIsIncluded()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        
+        // Act
+        services.AddDispatchR(cfg =>
+        {
+            cfg.Assemblies.Add(typeof(Fixture).Assembly);
+            cfg.RegisterPipelines = true;
+            cfg.RegisterNotifications = false;
+            cfg.IncludeHandlers = [Fixture.AnyHandlerRequestWithoutPipeline.GetType()];
+        });
+        
+        // Assert
+        Assert.DoesNotContain(services, p =>
+            p.IsKeyedService &&
+            p.KeyedImplementationType == Fixture.AnyStreamHandler.GetType());
+    }
+    
+    [Fact]
+    public void AddDispatchR_ReturnsExpectedResponse_IncludeSingleStreamHandler()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        
+        // Act
+        services.AddDispatchR(cfg =>
+        {
+            cfg.Assemblies.Add(typeof(Fixture).Assembly);
+            cfg.RegisterPipelines = true;
+            cfg.RegisterNotifications = false;
+            cfg.IncludeHandlers = [Fixture.AnyStreamHandler.GetType()];
+        });
+        
+        // Assert
+        Assert.Contains(services, p =>
+            p.IsKeyedService &&
+            p.KeyedImplementationType == Fixture.AnyStreamHandler.GetType());
+    }
+    
+    [Fact]
     public void AddDispatchR_ReturnsExpectedResponse_ExcludeSingleHandler()
     {
         // Arrange
@@ -97,6 +139,27 @@ public class AddDispatchRConfigurationTests
                 p.IsKeyedService && 
                 p.KeyedImplementationType == Fixture.AnyHandlerRequestWithoutPipeline.GetType());
         Assert.Equal(0, countOfAllSimpleHandlers);
+    }
+    
+    [Fact]
+    public void AddDispatchR_ReturnsExpectedResponse_ExcludeSingleStreamHandler()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        
+        // Act
+        services.AddDispatchR(cfg =>
+        {
+            cfg.Assemblies.Add(typeof(Fixture).Assembly);
+            cfg.RegisterPipelines = true;
+            cfg.RegisterNotifications = false;
+            cfg.ExcludeHandlers = [Fixture.AnyStreamHandler.GetType()];
+        });
+        
+        // Assert
+        Assert.DoesNotContain(services, p =>
+            p.IsKeyedService &&
+            p.KeyedImplementationType == Fixture.AnyStreamHandler.GetType());
     }
     
     [Fact]


### PR DESCRIPTION
## Summary

Fix `IncludeHandlers` / `ExcludeHandlers` filtering so concrete `IStreamRequestHandler<,>` implementations are filtered the same way as concrete `IRequestHandler<,>` implementations.

Previously, stream handlers were included in `otherHandlerTypes`, so they bypassed `IsHandlerIncluded(...)` and were registered even when they were not listed in `IncludeHandlers`.

## Changes

- Remove `streamRequestHandlerType` from `otherHandlerTypes`
- Detect concrete request handlers and concrete stream request handlers separately
- Apply `configurationOptions.IsHandlerIncluded(...)` to both handler categories
- Keep pipeline, stream pipeline, and notification discovery behavior unchanged

## Tests

Added regression coverage for:

- including only a request handler does not register stream handlers
- including a stream handler registers it
- excluding a stream handler prevents registration